### PR TITLE
Centre cooldown text better when under 10 seconds

### DIFF
--- a/Harmony Patches/Patches.cs
+++ b/Harmony Patches/Patches.cs
@@ -169,9 +169,14 @@ namespace ATLYSS_UiTweaks.Harmony_Patches
                                     {
                                         CooldownText.SetActive(true);
                                         CooldownText.GetComponent<Text>().text = ____pCast._skillCoolDowns[x].ToString("F1");
+                                        if (____pCast._skillCoolDowns[x] < 10f && CooldownText.transform.localPosition.x == 40f)
+                                        {
+                                            CooldownText.transform.localPosition = new Vector3(45f, 0f, 0f);
+                                        }
                                     }
                                     else
                                     {
+                                        CooldownText.transform.localPosition = new Vector3(40f,0f,0f);
                                         CooldownText.SetActive(false);
                                     }
                                 }


### PR DESCRIPTION
This just moves the cooldown text over to the right a bit when it's below 10 seconds to better centre it 

**Before**:
![t0ecDpWFqi](https://github.com/user-attachments/assets/29180008-c898-4678-84ed-1d8cdfe7f29e)

**After**:
![6X4GxFYx3I](https://github.com/user-attachments/assets/e89845df-a974-42fd-ad63-666aa8d81f47)
